### PR TITLE
Improve Parse method

### DIFF
--- a/IrcSays/Communication/Irc/IrcMessage.cs
+++ b/IrcSays/Communication/Irc/IrcMessage.cs
@@ -106,17 +106,16 @@ namespace IrcSays.Communication.Irc
 			var trailing = false;
 			while (pos < messageData.Length)
 			{
-				if (messageData[pos] == ':')
-				{
-					trailing = true;
-					pos++;
-				}
-
 				for (; pos < messageData.Length; pos++)
 				{
 					if (messageData[pos] == ' ' &&
 						!trailing)
 					{
+						if (messageData[pos + 1] == ':')
+						{
+							trailing = true;
+							pos++;
+						}
 						break;
 					}
 					sb.Append(messageData[pos]);


### PR DESCRIPTION
Updated Parse method so that trailing values are correctly identified via " :" instead of just ":". This fixes an unexpected behavior when parsing messages such as the following.

:card.freenode.net 005 TellYouHwat CHANTYPES=# EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 NETWORK=freenode KNOCK STATUSMSG=@+ CALLERID=g :are supported by this server
